### PR TITLE
fix: update Solidarity Fund nav subtext to "Give without giving."

### DIFF
--- a/src/constants/solidarityTools.ts
+++ b/src/constants/solidarityTools.ts
@@ -20,7 +20,7 @@ export const SOLIDARITY_TOOLS: SolidarityTool[] = [
   {
     id: "solidarity-fund",
     title: "Solidarity Fund",
-    shortDescription: "Fund post-capitalism.",
+    shortDescription: "Give without giving.",
     description:
       "Community coming together to fund what matters to us. Bake $BREAD and support projects you believe in.",
     color: "orange",


### PR DESCRIPTION
Closes #32.

Updates the subtext under the **Solidarity Fund** button in the nav bar Solutions dropdown.

| | Copy |
|---|---|
| Before | `Fund post-capitalism.` |
| After | `Give without giving.` |

One-line change in `src/constants/solidarityTools.ts` (`shortDescription`), which is rendered as the dropdown subtext in `Navbar.tsx` (line 118).

🤖 Generated with [Claude Code](https://claude.com/claude-code)