### PR TITLE
SEO: per-route metadata, structured data, robots/sitemap, llms.txt

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,25 @@
+# Bread Cooperative
+
+> A worker-owned software development cooperative building tools for financial solidarity. We build smart contracts and onchain systems, stablecoin and treasury systems, full-stack dApps and mobile apps, AI agents, and UX/UI — and we run the $BREAD engine and Solidarity Fund.
+
+## Pages
+
+- [Home](https://bread.coop/): Bread Cooperative — financial tools today, solidarity forever.
+- [Services](https://bread.coop/services): What we build for clients, industry clients, and testimonials.
+- [Solidarity Fund](https://bread.coop/solidarity-fund): Bake $BREAD, generate yield, and vote to direct it to member projects.
+- [Stacks](https://bread.coop/stacks): Onchain savings circles (ROSCAs) for trusted groups.
+
+## Docs & apps
+
+- [Documentation](https://docs.bread.coop): Manifesto, $BREAD token, voting power, and member-project guides.
+- [Solidarity Fund app](https://fund.bread.coop): The live Solidarity Fund application.
+- [Stacks app](https://stacks.bread.coop): The live Stacks application.
+- [Analytics dashboard](https://dune.com/bread_cooperative/solidarity): Onchain metrics for the Solidarity Fund.
+
+## Community
+
+- [GitHub](https://github.com/BreadchainCoop)
+- [X / Twitter](https://x.com/breadcoop)
+- [Farcaster](https://farcaster.xyz/~/channel/cryptoleft)
+- [Discord](https://discord.com/invite/zmNqsHRHDa)
+- [Newsletter](https://paragraph.com/@breadcoop)

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,12 +4,21 @@ import { GoogleAnalytics } from "@next/third-parties/google";
 import { ClientProviders } from "@/components/ClientProviders";
 
 export const metadata: Metadata = {
-  title: "Bread Cooperative",
+  metadataBase: new URL("https://bread.coop"),
+  title: {
+    default: "Bread Cooperative",
+    template: "%s | Bread Cooperative",
+  },
   description: "Tools for today. Solidarity forever.",
+  alternates: {
+    // Homepage canonical. Every other route overrides this with its own
+    // `alternates.canonical`, so this value only applies to "/".
+    canonical: "/",
+  },
   openGraph: {
     title: "Bread Cooperative",
     description: "Tools for today. Solidarity forever.",
-    url: "https://bread.coop/",
+    url: "/",
     siteName: "Bread Cooperative",
     images: [
       {
@@ -59,6 +68,39 @@ export const metadata: Metadata = {
   },
 };
 
+// Site-wide structured data. Content is maintainer-curated and verified against
+// the repo (src/constants/links.ts) — no fabricated values.
+const organizationLd = {
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  name: "Bread Cooperative",
+  legalName: "Bread Cooperative DAO LLC",
+  url: "https://bread.coop",
+  logo: "https://bread.coop/logo.svg",
+  email: "contact@bread.coop",
+  foundingDate: "2022",
+  description:
+    "A worker-owned software development cooperative building tools for financial solidarity",
+  sameAs: [
+    "https://github.com/BreadchainCoop",
+    "https://x.com/breadcoop",
+    "https://www.linkedin.com/company/bread-cooperative",
+    "https://www.youtube.com/@BreadCooperative",
+    "https://farcaster.xyz/~/channel/cryptoleft",
+    "https://paragraph.com/@breadcoop",
+    "https://discord.com/invite/zmNqsHRHDa",
+    "https://giveth.io/project/breadchain-cooperative",
+    "https://opencollective.com/bread-cooperative",
+  ],
+};
+
+const websiteLd = {
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  name: "Bread Cooperative",
+  url: "https://bread.coop",
+};
+
 export default function RootLayout({
   children,
 }: {
@@ -72,6 +114,14 @@ export default function RootLayout({
         />
       </head>
       <body className="font-roboto bg-paper-main text-text-standard antialiased">
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(organizationLd) }}
+        />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(websiteLd) }}
+        />
         <ClientProviders>{children}</ClientProviders>
       </body>
     </html>

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,11 @@
+import type { MetadataRoute } from "next";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    // Allow all crawlers, including AI bots (GPTBot, ClaudeBot, PerplexityBot,
+    // Google-Extended, CCBot) — resolved policy for bread.coop.
+    rules: [{ userAgent: "*", allow: "/" }],
+    sitemap: "https://bread.coop/sitemap.xml",
+    host: "https://bread.coop",
+  };
+}

--- a/src/app/services/_components/testimonials.tsx
+++ b/src/app/services/_components/testimonials.tsx
@@ -2,7 +2,7 @@ import { Body } from "@breadcoop/ui";
 import OverlappedHeading from "@/components/overlapped-heading";
 import Section from "./section";
 
-const TESTIMONIALS = [
+export const TESTIMONIALS = [
 	{
 		quote:
 			"Bread Cooperative was our Web3 partner on a project funded by the European Commission. They delivered the technical components reliably while patiently breaking down each piece so everyone involved understood what they were using and why. They're as good at explaining the work as they are at doing it.",

--- a/src/app/services/_components/what-we-can-develop.tsx
+++ b/src/app/services/_components/what-we-can-develop.tsx
@@ -13,7 +13,7 @@ const CHIP_COLORS: Record<ChipColor, string> = {
 	blue: "border-primary-blue text-primary-blue",
 };
 
-const SERVICES = [
+export const SERVICES = [
 	{
 		chip: "Solidity · EVM",
 		chipColor: "orange" as ChipColor,

--- a/src/app/services/page.tsx
+++ b/src/app/services/page.tsx
@@ -2,21 +2,85 @@ import type { Metadata } from "next";
 import { Footer } from "@/components/Footer/Footer";
 import { Navbar } from "@/components/Navbar/Navbar";
 import Hero from "./_components/hero";
-import WhatWeCanDevelop from "./_components/what-we-can-develop";
+import WhatWeCanDevelop, { SERVICES } from "./_components/what-we-can-develop";
 import IndustryClients from "./_components/industry-clients";
 import HowWeDeliver from "./_components/how-we-deliver";
 import FinalCTA from "./_components/final-cta";
-import Testimonials from "./_components/testimonials";
+import Testimonials, { TESTIMONIALS } from "./_components/testimonials";
+
+const description =
+	"Worker-owned development cooperative. Smart contract development, stablecoin and treasury systems, full-stack dApp and mobile development, AI agents and automation, UX/UI design and frontend. Trusted by the Ethereum Foundation, Curve Labs, and European Commission-funded projects.";
 
 export const metadata: Metadata = {
-	title: "Services | Bread Cooperative",
-	description:
-		"Worker-owned development cooperative. Smart contract development, stablecoin and treasury systems, full-stack dApp and mobile development, AI agents and automation, UX/UI design and frontend. Trusted by the Ethereum Foundation, Curve Labs, and European Commission-funded projects.",
+	title: "Services",
+	description,
+	alternates: { canonical: "/services" },
+	openGraph: {
+		title: "Services | Bread Cooperative",
+		description,
+		url: "/services",
+		siteName: "Bread Cooperative",
+		type: "website",
+	},
 };
+
+// Page-level structured data, built from the same data the page renders
+// (SERVICES / TESTIMONIALS) so there is one source of truth — no duplicated,
+// hand-maintained copies and no fabricated ratings.
+const servicesLd = {
+	"@context": "https://schema.org",
+	"@type": "Organization",
+	name: "Bread Cooperative",
+	url: "https://bread.coop",
+	hasOfferCatalog: {
+		"@type": "OfferCatalog",
+		name: "Services",
+		itemListElement: SERVICES.map((service) => ({
+			"@type": "Offer",
+			itemOffered: {
+				"@type": "Service",
+				name: service.title,
+				description: service.description,
+			},
+		})),
+	},
+};
+
+const reviewsLd = TESTIMONIALS.map((testimonial) => ({
+	"@context": "https://schema.org",
+	"@type": "Review",
+	itemReviewed: { "@type": "Organization", name: "Bread Cooperative" },
+	author: {
+		"@type": "Person",
+		name: testimonial.name,
+		worksFor: { "@type": "Organization", name: testimonial.role },
+	},
+	reviewBody: testimonial.quote,
+}));
+
+const breadcrumbLd = {
+	"@context": "https://schema.org",
+	"@type": "BreadcrumbList",
+	itemListElement: [
+		{ "@type": "ListItem", position: 1, name: "Home", item: "https://bread.coop/" },
+		{
+			"@type": "ListItem",
+			position: 2,
+			name: "Services",
+			item: "https://bread.coop/services",
+		},
+	],
+};
+
+const servicesJsonLd = [servicesLd, ...reviewsLd, breadcrumbLd];
 
 const Page = () => {
 	return (
 		<div className="min-h-screen overflow-x-hidden bg-paper-main flex flex-col">
+			<script
+				type="application/ld+json"
+				dangerouslySetInnerHTML={{ __html: JSON.stringify(servicesJsonLd) }}
+			/>
 			<Navbar static />
 			<main>
 				<Hero />

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,29 @@
+import type { MetadataRoute } from "next";
+
+const BASE_URL = "https://bread.coop";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const lastModified = new Date();
+
+  return [
+    { url: `${BASE_URL}/`, lastModified, changeFrequency: "monthly", priority: 1 },
+    {
+      url: `${BASE_URL}/services`,
+      lastModified,
+      changeFrequency: "monthly",
+      priority: 0.8,
+    },
+    {
+      url: `${BASE_URL}/stacks`,
+      lastModified,
+      changeFrequency: "monthly",
+      priority: 0.8,
+    },
+    {
+      url: `${BASE_URL}/solidarity-fund`,
+      lastModified,
+      changeFrequency: "monthly",
+      priority: 0.8,
+    },
+  ];
+}

--- a/src/app/solidarity-fund/layout.tsx
+++ b/src/app/solidarity-fund/layout.tsx
@@ -1,0 +1,28 @@
+import type { Metadata } from "next";
+
+// The /solidarity-fund page is a Client Component ("use client"), so it can't
+// export `metadata` itself. This route-level layout supplies its metadata and
+// simply renders the page unchanged.
+const description =
+  "The Bread Solidarity Fund: bake $BREAD, put your funds to work generating yield, and vote to direct that yield to the member projects you support. Give without giving — built for solidarity, not speculation.";
+
+export const metadata: Metadata = {
+  title: "Solidarity Fund",
+  description,
+  alternates: { canonical: "/solidarity-fund" },
+  openGraph: {
+    title: "Solidarity Fund | Bread Cooperative",
+    description,
+    url: "/solidarity-fund",
+    siteName: "Bread Cooperative",
+    type: "website",
+  },
+};
+
+export default function SolidarityFundLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/src/app/stacks/page.tsx
+++ b/src/app/stacks/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import { Footer } from "@/components/Footer/Footer";
 import { Navbar } from "@/components/Navbar/Navbar";
 import Intro from "./_components/intro";
@@ -6,6 +7,22 @@ import HowItWorks from "./_components/how-it-works";
 import Ready from "./_components/ready";
 import Tools from "./_components/tools";
 import CanDoWithStacks from "./_components/can-do-with-stacks";
+
+const description =
+	"Stack money together with your trusted group: everyone contributes the same amount each round and one member claims the pooled lump sum, taking turns until everyone has claimed. Savings circles onchain — no loans, no credit.";
+
+export const metadata: Metadata = {
+	title: "Stacks",
+	description,
+	alternates: { canonical: "/stacks" },
+	openGraph: {
+		title: "Stacks | Bread Cooperative",
+		description,
+		url: "/stacks",
+		siteName: "Bread Cooperative",
+		type: "website",
+	},
+};
 
 const Page = () => {
 	return (


### PR DESCRIPTION
Implements the on-site SEO/metadata work from #36. **Markup & metadata only** — no page copy or heading changes (Workstream 4 / `<h1>` hygiene remains the front-end dev's).

> Re-opened as a fresh PR: the original #41 was auto-closed after a force-push that (via a shallow-clone amend) briefly orphaned the branch from `main`. History is now correct and based on current `main`; content is unchanged.

## What's included

**Per-route metadata**
- `layout.tsx`: `metadataBase` (`https://bread.coop`) + `title.template` (`"%s | Bread Cooperative"`); homepage `canonical` `/` (each route overrides it).
- Unique `title` / `description` / `alternates.canonical` / per-page `openGraph` on `/services`, `/stacks`, `/solidarity-fund`.
- `/` and `/solidarity-fund` are Client Components (`"use client"`) and can't export `metadata`, so no page was refactored: home rides the root-layout metadata, and `/solidarity-fund` gets a small route-level `layout.tsx` that carries its metadata.
- `/stacks` and `/solidarity-fund` descriptions **summarize existing on-page copy** — nothing invented.

**Structured data (JSON-LD)**
- Site-wide `Organization` + `WebSite` in `layout.tsx`. Values verified against the repo (`src/constants/links.ts`) / maintainer-confirmed; no fabricated data. `sameAs` normalized to `https`. `WebSite` has no `SearchAction` (no site search exists).
- `/services`: `Organization` + `OfferCatalog` (6 services), 3 × `Review`, `BreadcrumbList` — built by mapping the now-exported `SERVICES` / `TESTIMONIALS` arrays, so the page render and the schema share one source of truth. **No star ratings** (none exist).

**Crawl & discovery**
- `src/app/robots.ts` — allow all crawlers, incl. AI bots (GPTBot, ClaudeBot, PerplexityBot, Google-Extended, CCBot).
- `src/app/sitemap.ts` — all 4 routes.
- `public/llms.txt`.

## Verification (local production build)
- `pnpm build` passes (13/13 static pages); `pnpm lint` clean on all touched files.
- `/robots.txt` and `/sitemap.xml` return 200.
- Each route emits a unique `<title>`, `rel=canonical`, and `og:url`.

Before merge, worth a pass through the [Rich Results Test](https://search.google.com/test/rich-results) and [Schema Markup Validator](https://validator.schema.org/) on a deploy preview for `/services`.

Closes #36. Supersedes #41.
